### PR TITLE
pool:is_pool always evaluates to 'false'. Should use a "!=" value comparison instead of "is not"

### DIFF
--- a/voipbox_plugin/models.py
+++ b/voipbox_plugin/models.py
@@ -87,7 +87,7 @@ class Pool(NetBoxModel):
 
     @property
     def is_pool(self):
-        return self.start is not self.end
+        return self.start != self.end
 
     def clean(self):
         if self.start > self.end:


### PR DESCRIPTION
Pool:is_pool` always evaluates to false, due to the use of a memory comparator between self.start and self.end, instead of a value comparator.  This commit changes the 'is not' comparison to "!=".