### PR TITLE
Fix: Invalid permission name

### DIFF
--- a/voipbox_plugin/views.py
+++ b/voipbox_plugin/views.py
@@ -25,7 +25,7 @@ class PoolView(generic.ObjectView):
     tab = ViewTab(
         label=_('Child pools'),
         badge=lambda x: x.get_children().count(),
-        permission='plugins:voipbox_plugin:view_pool',
+        permission='voipbox_plugin:view_pool',
         weight=600
     )
 


### PR DESCRIPTION
This PR fixes the pool view on Netbox 4.4. The fix isn't tested on older version of Netbox.