### PR TITLE
Fix invalid permission name

### DIFF
--- a/voipbox_plugin/views.py
+++ b/voipbox_plugin/views.py
@@ -25,7 +25,7 @@ class PoolView(generic.ObjectView):
     tab = ViewTab(
         label=_('Child pools'),
         badge=lambda x: x.get_children().count(),
-        permission='voipbox_plugin:view_pool',
+        permission='voipbox_plugin.view_pool',
         weight=600
     )
 


### PR DESCRIPTION
The previous attempt to fix the permission issue still has an incorrect format ... should be 'voipbox_plugin.view_pool' instead of 'voipbox_plugin:view_pool'.